### PR TITLE
feat: inject all pools for arbitrage

### DIFF
--- a/examples/solver/amm-solver/src/lib.rs
+++ b/examples/solver/amm-solver/src/lib.rs
@@ -185,6 +185,9 @@ fn must_support(pair: &String) -> Result<(), StdError> {
 }
 
 // Arbitrage supports astroport + raydium for now
+// fis_input injects all pool for now
+// format: 
+// [wasm btc-usdt, svm btc-usdt, wasm eth-usdt, svm btc-usdt, wasm sol-usdt, svm sol-usdt]
 pub fn arbitrage(
     deps: Deps,
     env: Env,
@@ -194,8 +197,7 @@ pub fn arbitrage(
     fis_input: &Vec<FISInput>,
 ) -> StdResult<Binary> {
     must_support(&pair)?;
-    // btc-usdt, eth-usdt, sol-usdt
-    let pair_index = match pair.as_str() {
+    let pool_index = match pair.as_str() {
         "btc-usdt" => 0,
         "eth-usdt" => 2,
         "sol-usdt" => 4,
@@ -204,10 +206,10 @@ pub fn arbitrage(
 
     let raw_pools = [
         fis_input
-            .get(pair_index)
+            .get(pool_index)
             .ok_or(StdError::generic_err("astroport pool data not found"))?,
         fis_input
-            .get(pair_index+1)
+            .get(pool_index+1)
             .ok_or(StdError::generic_err("raydium pool data not found"))?,
     ];
 

--- a/examples/solver/amm-solver/src/lib.rs
+++ b/examples/solver/amm-solver/src/lib.rs
@@ -13,12 +13,12 @@ use cosmwasm_std::{
     MessageInfo, Response, StdResult, Uint128,
 };
 use cosmwasm_std::{from_json, Isqrt, StdError};
-use evm::uniswap::{UniswapPool, UNISWAP};
+use evm::uniswap::UniswapPool;
 use std::cmp::min;
 use std::vec::Vec;
 use svm::get_denom;
-use svm::raydium::{RaydiumPool, RAYDIUM};
-use wasm::astroport::{AstroportPool, ASTROPORT};
+use svm::raydium::RaydiumPool;
+use wasm::astroport::AstroportPool;
 
 #[cw_serde]
 pub struct InstantiateMsg {}

--- a/examples/solver/amm-solver/src/lib.rs
+++ b/examples/solver/amm-solver/src/lib.rs
@@ -194,13 +194,20 @@ pub fn arbitrage(
     fis_input: &Vec<FISInput>,
 ) -> StdResult<Binary> {
     must_support(&pair)?;
+    // btc-usdt, eth-usdt, sol-usdt
+    let pair_index = match pair.as_str() {
+        "btc-usdt" => 0,
+        "eth-usdt" => 2,
+        "sol-usdt" => 4,
+        _ => unreachable!()
+    };
 
     let raw_pools = [
         fis_input
-            .first()
+            .get(pair_index)
             .ok_or(StdError::generic_err("astroport pool data not found"))?,
         fis_input
-            .get(1)
+            .get(pair_index+1)
             .ok_or(StdError::generic_err("raydium pool data not found"))?,
     ];
 

--- a/examples/solver/plane-util/src/lib.rs
+++ b/examples/solver/plane-util/src/lib.rs
@@ -136,7 +136,7 @@ pub fn query(_deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
             let address = env.contract.address;
             let balance = from_json::<Coin>(fis_input.get(0).unwrap()).unwrap();
             assert!(
-                balance.amount.le(&amount),
+                amount <= balance.amount,
                 "transfer amount must not exceed current balance"
             );
             let divided_amount = amount.checked_div(Uint256::from(3u128)).unwrap();


### PR DESCRIPTION
- Since FE schema doesn't have ability to select related pool for query, we assume all pools are injected in FIS query
- Minor fix plane_util `deposit_equally` amount check logic