### PR TITLE
feat(amm): adapt svm link changes to all nexus actions

### DIFF
--- a/examples/solver/amm-solver/src/astromesh.rs
+++ b/examples/solver/amm-solver/src/astromesh.rs
@@ -46,6 +46,7 @@ pub struct Swap {
     pub sender: String,
     pub denom: String,
     pub amount: Int128,
+    pub sender_svm: String,
 }
 
 pub trait Pool {

--- a/examples/solver/amm-solver/src/svm.rs
+++ b/examples/solver/amm-solver/src/svm.rs
@@ -417,10 +417,8 @@ pub mod raydium {
 
         fn compose_swap_fis(&self, swap: &Swap) -> Result<Vec<FISInstruction>, StdError> {
             let accounts = get_pool_accounts_by_name(&swap.pool_name)?;
-            let (_, sender_bz) = bech32::decode(swap.sender.as_str()).unwrap();
-            let sender_svm_account: Pubkey =
-                Pubkey::from_slice(keccak256(sender_bz.as_slice()).as_slice())
-                    .map_err(|e| StdError::generic_err(format!("parse svm err: {}", e)))?;
+            let sender_svm_account = Pubkey::from_string(&swap.sender_svm)
+                .map_err(|e| StdError::generic_err(format!("parse svm address err: {}", e)))?;
             let input_denom = get_denom(&swap.denom);
             let mut amount = swap.amount;
             if input_denom == get_denom("eth") {


### PR DESCRIPTION
To work with new svm account link changes, this PR adds sender_svm for arbitrage bot nexus actions

Refactored and test with sdk-go example:
<img width="689" alt="image" src="https://github.com/user-attachments/assets/9bd65a7c-ac91-4cfd-bdd0-7f0878d874a6">
