### PR TITLE
fix(misc): params uint64, parse non-existing account 

### DIFF
--- a/examples/solver/drift-solver/src/astromesh.rs
+++ b/examples/solver/drift-solver/src/astromesh.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Binary, Coin, Int128, Int256, Uint256, Uint64};
+use cosmwasm_std::{Binary, Coin, Int128, Uint64};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/examples/solver/drift-solver/src/astromesh.rs
+++ b/examples/solver/drift-solver/src/astromesh.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Binary, Coin, Int128, Int256, Uint256};
+use cosmwasm_std::{Binary, Coin, Int128, Int256, Uint256, Uint64};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -50,13 +50,13 @@ pub enum NexusAction {
     PlacePerpMarketOrder {
         direction: String,
         usdt_amount: Int128,
-        leverage: u8,
+        leverage: Uint64,
         market: String,
-        auction_duration: u8,
+        auction_duration: Uint64,
     },
     FillPerpMarketOrder {
         taker_svm_address: String,
-        taker_order_id: u32,
-        percent: u8,
+        taker_order_id: Uint64,
+        percent: Uint64,
     },
 }

--- a/examples/solver/drift-solver/src/lib.rs
+++ b/examples/solver/drift-solver/src/lib.rs
@@ -195,7 +195,7 @@ pub fn place_perp_market_order(
     // 2. deposit usdt
     let quote_asset_amount = usdt_amount.i128() as u64;
     let cosmos_addr = env.contract.address.to_string();
-    let astro_transfer_ix = astro_transfer(cosmos_addr.clone(), 1_000_000_000);
+    let astro_transfer_ix = astro_transfer(cosmos_addr.clone(), quote_asset_amount);
     instructions.extend(astro_transfer_ix);
 
     let deposit_ixs = create_deposit_usdt_ix(deps, svm_addr.clone(), quote_asset_amount)?;

--- a/examples/solver/drift-solver/src/lib.rs
+++ b/examples/solver/drift-solver/src/lib.rs
@@ -213,7 +213,7 @@ pub fn place_perp_market_order(
         order_direction = PositionDirection::Short;
         (start_price, end_price) = (market_price * 1002 / 1000, market_price);
     }
-    let expire_time = env.block.time.seconds() as i64 + 30;
+    let expire_time = env.block.time.seconds() as i64 + 120;
 
     // base_asset_amount = usdt_amount * leverage / price
     let order_params = OrderParams {

--- a/examples/solver/drift-solver/src/lib.rs
+++ b/examples/solver/drift-solver/src/lib.rs
@@ -132,7 +132,7 @@ pub fn place_perp_market_order(
         )))
     }
 
-    let auction_duration = auction_duration.u64() as u8;
+    let auction_duration = auction_duration.u64();
     if auction_duration < 10 || auction_duration > 255 {
         return Err(StdError::generic_err(format!(
             "acution_duration must be integer in range 10..255. Actual: {}",
@@ -230,7 +230,7 @@ pub fn place_perp_market_order(
         trigger_price: Some(0),
         trigger_condition: OrderTriggerCondition::Above,
         oracle_price_offset: Some(0),
-        auction_duration: Some(auction_duration),
+        auction_duration: Some(auction_duration as u8),
         auction_start_price: Some(start_price.try_into().unwrap()),
         auction_end_price: Some(end_price.try_into().unwrap()),
     };


### PR DESCRIPTION
# Context

This PR adds some misc fixes, as they're small, I bundled in same PR

1/ [FE integration] now FE just understand type `number` and is sending json with number quoted (e.g {"percent":"10"}, which cannot distinguish between bigint (having quote) and small int (<= u32) (no quotes) => rust throws error 
**Solution:**
Unify number type to support quoted number (changed to Uint64) because it's simple enough for the release + backward compatible with other stuff
We can make the number types more flexible later, for now it has no much value

2/ Can't parse non-existing user account to get next_order_id => thus use next_order_id = 1 (used by default by drift)

Tested on FE with schema, looks good 

![image](https://github.com/user-attachments/assets/9945c4b2-e5b0-4dd6-a4c0-d597c52b466e)

3/ Small fixes to check type limit and include existing order_id when people type in fill orders
We should improve FE to include existing order id for the users