### PR TITLE
fix: undelegate action

### DIFF
--- a/examples/solver/staking-solver/src/astromesh.rs
+++ b/examples/solver/staking-solver/src/astromesh.rs
@@ -108,3 +108,22 @@ pub struct Pagination {
     pub next_key: Option<String>, // This could be null, so use Option
     pub total: String,
 }
+
+#[cw_serde]
+pub struct DelegationResponse {
+    pub delegation_responses: Vec<Delegation>,
+    pub pagination: Pagination,
+}
+
+#[cw_serde]
+pub struct Delegation {
+    pub delegation: DelegationDetail,
+    pub balance: Coin,
+}
+
+#[cw_serde]
+pub struct DelegationDetail {
+    pub delegator_address: String,
+    pub validator_address: String,
+    pub shares: String,
+}

--- a/examples/solver/staking-solver/src/bin/schema.rs
+++ b/examples/solver/staking-solver/src/bin/schema.rs
@@ -74,7 +74,7 @@ fn main() {
                     action: "COSMOS_QUERY".to_string(),
                     address: Binary::new(vec![]),
                     input: vec![Binary::from(
-                        "/cosmos/distribution/v1beta1/delegators/${wallet}/rewards".as_bytes(),
+                        "/cosmos/staking/v1beta1/delegations/${wallet}".as_bytes(),
                     )],
                 },
                 QueryInstruction {

--- a/examples/solver/staking-solver/src/bin/schema.rs
+++ b/examples/solver/staking-solver/src/bin/schema.rs
@@ -42,31 +42,25 @@ pub struct Schema {
 }
 
 fn main() {
-
     let delegate_prompt = Prompt {
-        template: "delegate ${amount:number} lux to validator ${validator_name:string}"
-            .to_string(),
+        template: "delegate ${amount:number} lux to validator ${validator_name:string}".to_string(),
         msg_fields: vec!["amount".to_string(), "validator_name".to_string()],
         query: Query {
-            instructions: vec![
-                QueryInstruction {
-                    plane: "COSMOS".to_string(),
-                    action: "COSMOS_QUERY".to_string(),
-                    address: Binary::new(vec![]),
-                    input: vec![Binary::from(
-                        "/cosmos/staking/v1beta1/validators".as_bytes(),
-                    )],
-                },
-            ],
+            instructions: vec![QueryInstruction {
+                plane: "COSMOS".to_string(),
+                action: "COSMOS_QUERY".to_string(),
+                address: Binary::new(vec![]),
+                input: vec![Binary::from(
+                    "/cosmos/staking/v1beta1/validators".as_bytes(),
+                )],
+            }],
         },
     };
 
     let undelegate_prompt = Prompt {
-        template: "undelegate ${amount:number} lux from validator ${validator_name:string}".to_string(),
-        msg_fields: vec![
-            "amount".to_string(),
-            "validator_name".to_string(),
-        ],
+        template: "undelegate ${amount:number} lux from validator ${validator_name:string}"
+            .to_string(),
+        msg_fields: vec!["amount".to_string(), "validator_name".to_string()],
         query: Query {
             instructions: vec![
                 QueryInstruction {
@@ -89,41 +83,36 @@ fn main() {
         },
     };
 
-    
-    
     let claim_all_rewards_prompt = Prompt {
         template: "claim all rewards from all validators".to_string(),
         msg_fields: vec![],
         query: Query {
-            instructions: vec![
-                QueryInstruction {
-                    plane: "COSMOS".to_string(),
-                    action: "COSMOS_QUERY".to_string(),
-                    address: Binary::new(vec![]),
-                    input: vec![Binary::from(
-                        "/cosmos/distribution/v1beta1/delegators/${wallet}/rewards".as_bytes(),
-                    )],
-                }],
-            },
-        };
-        
-        
+            instructions: vec![QueryInstruction {
+                plane: "COSMOS".to_string(),
+                action: "COSMOS_QUERY".to_string(),
+                address: Binary::new(vec![]),
+                input: vec![Binary::from(
+                    "/cosmos/distribution/v1beta1/delegators/${wallet}/rewards".as_bytes(),
+                )],
+            }],
+        },
+    };
+
     let claim_rewards_and_redelegate_prompt = Prompt {
         template: "claim all rewards and delegate to same validators".to_string(),
         msg_fields: vec![],
         query: Query {
-            instructions: vec![
-                QueryInstruction {
-                    plane: "COSMOS".to_string(),
-                    action: "COSMOS_QUERY".to_string(),
-                    address: Binary::new(vec![]),
-                    input: vec![Binary::from(
-                        "/cosmos/distribution/v1beta1/delegators/${wallet}/rewards".as_bytes(),
-                    )],
-                }],
-            },
-        };
-        
+            instructions: vec![QueryInstruction {
+                plane: "COSMOS".to_string(),
+                action: "COSMOS_QUERY".to_string(),
+                address: Binary::new(vec![]),
+                input: vec![Binary::from(
+                    "/cosmos/distribution/v1beta1/delegators/${wallet}/rewards".as_bytes(),
+                )],
+            }],
+        },
+    };
+
     let redelegate_prompt = Prompt {
         template: "move ${amount:number} lux from validator ${src_validator_address:string} to ${new_validator_address:string}".to_string(),
         msg_fields: vec![
@@ -163,7 +152,7 @@ fn main() {
             claim_rewards_and_redelegate: claim_rewards_and_redelegate_prompt,
         },
     };
-            
+
     // Creating the schema
     let schema = Schema {
         groups: vec![group],

--- a/examples/solver/staking-solver/src/bin/schema.rs
+++ b/examples/solver/staking-solver/src/bin/schema.rs
@@ -108,63 +108,63 @@ fn main() {
         };
         
         
-        let claim_rewards_and_redelegate_prompt = Prompt {
-            template: "claim all rewards and delegate to same validators".to_string(),
-            msg_fields: vec![],
-            query: Query {
-                instructions: vec![
-                    QueryInstruction {
-                        plane: "COSMOS".to_string(),
-                        action: "COSMOS_QUERY".to_string(),
-                        address: Binary::new(vec![]),
-                        input: vec![Binary::from(
-                            "/cosmos/distribution/v1beta1/delegators/${wallet}/rewards".as_bytes(),
-                        )],
-                    }],
+    let claim_rewards_and_redelegate_prompt = Prompt {
+        template: "claim all rewards and delegate to same validators".to_string(),
+        msg_fields: vec![],
+        query: Query {
+            instructions: vec![
+                QueryInstruction {
+                    plane: "COSMOS".to_string(),
+                    action: "COSMOS_QUERY".to_string(),
+                    address: Binary::new(vec![]),
+                    input: vec![Binary::from(
+                        "/cosmos/distribution/v1beta1/delegators/${wallet}/rewards".as_bytes(),
+                    )],
+                }],
+            },
+        };
+        
+    let redelegate_prompt = Prompt {
+        template: "move ${amount:number} lux from validator ${src_validator_address:string} to ${new_validator_address:string}".to_string(),
+        msg_fields: vec![
+            "amount".to_string(),
+            "src_validator_address".to_string(),
+            "new_validator_address".to_string(),
+        ],
+        query: Query {
+            instructions: vec![
+                QueryInstruction {
+                    plane: "COSMOS".to_string(),
+                    action: "COSMOS_QUERY".to_string(),
+                    address: Binary::new(vec![]),
+                    input: vec![Binary::from(
+                        "/cosmos/distribution/v1beta1/delegators/${wallet}/rewards".as_bytes(),
+                    )],
                 },
-            };
-            
-            let redelegate_prompt = Prompt {
-                template: "move ${amount:number} lux from validator ${src_validator_address:string} to ${new_validator_address:string}".to_string(),
-                msg_fields: vec![
-                    "amount".to_string(),
-                    "src_validator_address".to_string(),
-                    "new_validator_address".to_string(),
-                ],
-                query: Query {
-                    instructions: vec![
-                        QueryInstruction {
-                            plane: "COSMOS".to_string(),
-                            action: "COSMOS_QUERY".to_string(),
-                            address: Binary::new(vec![]),
-                            input: vec![Binary::from(
-                                "/cosmos/distribution/v1beta1/delegators/${wallet}/rewards".as_bytes(),
-                            )],
-                        },
-                        QueryInstruction {
-                            plane: "COSMOS".to_string(),
-                            action: "COSMOS_QUERY".to_string(),
-                            address: Binary::new(vec![]),
-                            input: vec![Binary::from(
-                                "/cosmos/staking/v1beta1/validators".as_bytes(),
-                            )],
-                        },
-                    ],
+                QueryInstruction {
+                    plane: "COSMOS".to_string(),
+                    action: "COSMOS_QUERY".to_string(),
+                    address: Binary::new(vec![]),
+                    input: vec![Binary::from(
+                        "/cosmos/staking/v1beta1/validators".as_bytes(),
+                    )],
                 },
-            };
+            ],
+        },
+    };
 
-            // Constructing the group "Staking Solver"
-            let group = Group {
-                name: "Staking Solver".to_string(),
-                prompts: Prompts {
-                    delegate: delegate_prompt,
-                    undelegate: undelegate_prompt,
-                    claim_all_rewards: claim_all_rewards_prompt,
-                    claim_rewards_and_redelegate: claim_rewards_and_redelegate_prompt,
-                },
-            };
+    // Constructing the group "Staking Solver"
+    let group = Group {
+        name: "Staking Solver".to_string(),
+        prompts: Prompts {
+            delegate: delegate_prompt,
+            undelegate: undelegate_prompt,
+            claim_all_rewards: claim_all_rewards_prompt,
+            claim_rewards_and_redelegate: claim_rewards_and_redelegate_prompt,
+        },
+    };
             
-            // Creating the schema
+    // Creating the schema
     let schema = Schema {
         groups: vec![group],
     };


### PR DESCRIPTION
# Context


This PR fixes the Undelegate action in the Staking Solver
Problem
- Get the reward to check the last amount instead of retrieving the balance
- Send two messages (undelegate and get rewards), but we don’t need both.

Solution
- Change from get reward to get balance in undelegate action
- Remove get rewards after undelegate

# Test


Test with FE
Delegate
<img width="495" alt="image" src="https://github.com/user-attachments/assets/61c4b75f-5d78-47cf-8fd3-23fd5a222a13">

Undelegate 
<img width="499" alt="image" src="https://github.com/user-attachments/assets/c62b2e11-693f-4722-a798-cf1fcf100f3a">

Claim all rewards
<img width="507" alt="image" src="https://github.com/user-attachments/assets/f8c7e744-ccdb-4518-853a-89f724f754f4">

Claim all rewards and redelegate
<img width="514" alt="image" src="https://github.com/user-attachments/assets/9e918ccc-7663-468c-8668-a2f4ce9c8b7a">


<img width="724" alt="image" src="https://github.com/user-attachments/assets/5c10bcb6-be59-47af-bdc7-22229b8acfe9">
