### PR TITLE
chore(dumpsad): unify buy/sell action to trade

### DIFF
--- a/examples/solver/dumpsad-solver/src/astromesh.rs
+++ b/examples/solver/dumpsad-solver/src/astromesh.rs
@@ -94,12 +94,8 @@ pub enum NexusAction {
         solver_id: String,
         cron_id: String,
     },
-    Buy {
-        denom: String,
-        amount: Uint128,
-        slippage: Uint128,
-    },
-    Sell {
+    Trade {
+        action: String,
         denom: String,
         amount: Uint128,
         slippage: Uint128,


### PR DESCRIPTION
[Ux enhancement], 
People can do trade (buy/sell) on one single prompt. (e.g [Buy] 10 [SOL] for WIF, slippage [2%] or [Sell] 1000 [WIF], slippage 3%)
FE needs to unify 2 actions of buy/sell into one, this PR make this happen conveniently

Tested with sdk-go 
https://github.com/FluxAstromeshLabs/sdk-go/pull/33