### PR TITLE
f/add transfer fee

### DIFF
--- a/examples/cron/dumpsad-cron/src/events.rs
+++ b/examples/cron/dumpsad-cron/src/events.rs
@@ -19,4 +19,5 @@ pub struct GraduateEvent {
     pub vm: String,
     pub pool_svm_address: String,
     pub meme_denom_link: String,
+    pub token_creator: String,
 }

--- a/examples/cron/dumpsad-cron/src/evm.rs
+++ b/examples/cron/dumpsad-cron/src/evm.rs
@@ -271,7 +271,7 @@ pub mod uniswap {
         let tick_upper = compute_tick(upper_price, tick_spacing.into());
 
         let modify_liquidity_params =
-            ModifyLiquidityParams::new(tick_lower, tick_upper, 1000, salt);
+            ModifyLiquidityParams::new(tick_lower, tick_upper, 1000000000, salt);
         let empty_hook_data: [u8; 64] = [
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 1, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/examples/solver/dumpsad-solver/src/events.rs
+++ b/examples/solver/dumpsad-solver/src/events.rs
@@ -34,4 +34,5 @@ pub struct GraduateEvent {
     pub vm: String,
     pub pool_svm_address: String,
     pub meme_denom_link: String,
+    pub token_creator: String,
 }

--- a/examples/solver/dumpsad-solver/src/lib.rs
+++ b/examples/solver/dumpsad-solver/src/lib.rs
@@ -390,6 +390,7 @@ fn handle_buy(
                 vm: pool_state.vm,
                 pool_svm_address: pool_state.pool_svm_address,
                 meme_denom_link: pool_state.meme_denom_link,
+                token_creator: pool_res.pool.operator_addr,
             })?,
         });
     }


### PR DESCRIPTION
This PR for:
- Add transfer fees for the token's creator and the pool's creator when graduate
- Adjust fees and liquidity delta in Uniswap pool

<img width="361" alt="image" src="https://github.com/user-attachments/assets/34ea5006-a363-45de-aa5f-df9066ef77ae" />
<img width="361" alt="image" src="https://github.com/user-attachments/assets/fcad8a56-95fd-4db4-b024-ad83ed74106a" />


Transfer 0.5 * 10^9 (sol) for token's creator and 1.5 * 10^9 (sol) for pool's creator

test with sdk-go
<img width="765" alt="image" src="https://github.com/user-attachments/assets/e5fd4be8-9437-40cc-966c-0324f888c19c" />
